### PR TITLE
fix: undefined symbol: glamor_egl_init_textured_pixmap fixes #4

### DIFF
--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -453,11 +453,6 @@ Bool amdgpu_glamor_init(ScreenPtr screen)
 		return FALSE;
 	}
 
-	if (!glamor_egl_init_textured_pixmap(screen)) {
-		xf86DrvMsg(scrn->scrnIndex, X_ERROR,
-			   "Failed to initialize textured pixmap of screen for glamor.\n");
-		return FALSE;
-	}
 	if (!dixRegisterPrivateKey(&amdgpu_pixmap_index, PRIVATE_PIXMAP, 0))
 		return FALSE;
 


### PR DESCRIPTION
The function just returns true now so there is no point to this code which fails to find the function symbol any way.