### PR TITLE
fix missing include of <xorg-config.h>

### DIFF
--- a/src/amdgpu_bo_helper.c
+++ b/src/amdgpu_bo_helper.c
@@ -25,6 +25,9 @@
 #endif
 #include <sys/mman.h>
 #include <gbm.h>
+
+#include <xorg-server.h>
+
 #include "amdgpu_drv.h"
 #include "amdgpu_bo_helper.h"
 #include "amdgpu_glamor.h"

--- a/src/amdgpu_dri2.c
+++ b/src/amdgpu_dri2.c
@@ -29,6 +29,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include "amdgpu_drv.h"
 #include "amdgpu_dri2.h"
 #include "amdgpu_glamor.h"

--- a/src/amdgpu_dri3.c
+++ b/src/amdgpu_dri3.c
@@ -26,6 +26,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include "amdgpu_drv.h"
 
 #ifdef HAVE_DRI3_H

--- a/src/amdgpu_drm_queue.c
+++ b/src/amdgpu_drm_queue.c
@@ -30,6 +30,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <errno.h>
 
 #include <xorg-server.h>

--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -28,6 +28,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #ifdef USE_GLAMOR
 
 #include <xf86.h>

--- a/src/amdgpu_glamor_wrappers.c
+++ b/src/amdgpu_glamor_wrappers.c
@@ -32,6 +32,8 @@
 #include <config.h>
 #endif
 
+#include <xorg-server.h>
+
 #include <fb.h>
 #include <fbpict.h>
 

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -28,6 +28,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <errno.h>
 #include <sys/ioctl.h>
 

--- a/src/amdgpu_misc.c
+++ b/src/amdgpu_misc.c
@@ -24,6 +24,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include "amdgpu_probe.h"
 #include "amdgpu_version.h"
 

--- a/src/amdgpu_pixmap.c
+++ b/src/amdgpu_pixmap.c
@@ -26,6 +26,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <xf86.h>
 #include "amdgpu_pixmap.h"
 #include "amdgpu_bo_helper.h"

--- a/src/amdgpu_present.c
+++ b/src/amdgpu_present.c
@@ -25,6 +25,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include "amdgpu_drv.h"
 
 #ifdef HAVE_PRESENT_H

--- a/src/amdgpu_probe.c
+++ b/src/amdgpu_probe.c
@@ -30,6 +30,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/amdgpu_sync.c
+++ b/src/amdgpu_sync.c
@@ -20,6 +20,7 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
+#include <xorg-server.h>
 
 #include "amdgpu_drv.h"
 

--- a/src/amdgpu_video.c
+++ b/src/amdgpu_video.c
@@ -3,6 +3,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -29,6 +29,8 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <time.h>


### PR DESCRIPTION
All source files should include xorg-config at the very top: this is necessary to define all the necessary (potentially platform specific) symbols consumed by other xserver SDK headers. We really shouldn't rely on this one being included "by accident" somewhere else - include order really matters here.