### PR TITLE
fix missing includes of fb.h

### DIFF
--- a/src/amdgpu_glamor_wrappers.c
+++ b/src/amdgpu_glamor_wrappers.c
@@ -32,6 +32,7 @@
 #include <config.h>
 #endif
 
+#include <fb.h>
 #include <fbpict.h>
 
 #ifdef USE_GLAMOR

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -30,6 +30,9 @@
 
 #include <errno.h>
 #include <sys/ioctl.h>
+
+#include "fb.h"
+
 /* Driver data structures */
 #include "amdgpu_drv.h"
 #include "amdgpu_bo_helper.h"


### PR DESCRIPTION
Some source files calling functions from fb.h, so this needs to be included there.