### PR TITLE
drop checking HAS_DIRTYTRACKING_DRAWABLE_SRC

### DIFF
--- a/src/amdgpu_drv.h
+++ b/src/amdgpu_drv.h
@@ -186,11 +186,7 @@ amdgpu_dirty_primary(PixmapDirtyUpdatePtr dirty)
 static inline DrawablePtr
 amdgpu_dirty_src_drawable(PixmapDirtyUpdatePtr dirty)
 {
-#ifdef HAS_DIRTYTRACKING_DRAWABLE_SRC
 	return dirty->src;
-#else
-	return &dirty->src->drawable;
-#endif
 }
 
 static inline Bool

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -1817,14 +1817,9 @@ static Bool drmmode_set_scanout_pixmap(xf86CrtcPtr crtc, PixmapPtr ppix)
 
 	drmmode_crtc->prime_scanout_pixmap = ppix;
 
-#ifdef HAS_DIRTYTRACKING_DRAWABLE_SRC
 	PixmapStartDirtyTracking(&ppix->drawable,
 				 drmmode_crtc->scanout[scanout_id],
 				 0, 0, 0, 0, RR_Rotate_0);
-#else
-	PixmapStartDirtyTracking(ppix, drmmode_crtc->scanout[scanout_id],
-				 0, 0, 0, 0, RR_Rotate_0);
-#endif
 	return TRUE;
 }
 


### PR DESCRIPTION
This symbol is always set since about a decade ago - no need to support ancient Xserver versions anymore.