### PR TITLE
configure.ac: no need to check for misyncshm.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,12 +181,6 @@ AC_CHECK_DECL(GBM_BO_USE_FRONT_RENDERING,
 	      [#include <stdlib.h>
 	       #include <gbm.h>])
 
-AC_CHECK_HEADERS([misyncshm.h], [], [],
-                 [#include <X11/Xdefs.h>
-	          #include <X11/Xfuncproto.h>
-	          #include <xorg-server.h>
-		  #include <screenint.h>])
-
 AC_CHECK_HEADERS([present.h], [], [],
 		 [#include <X11/Xmd.h>
 		 #include <X11/Xproto.h>

--- a/src/amdgpu_sync.c
+++ b/src/amdgpu_sync.c
@@ -23,8 +23,6 @@
 
 #include "amdgpu_drv.h"
 
-#ifdef HAVE_MISYNCSHM_H
-
 #include "misync.h"
 #include "misyncshm.h"
 #include "misyncstr.h"
@@ -133,22 +131,3 @@ amdgpu_sync_close(ScreenPtr screen)
 
 	info->CreateFence = NULL;
 }
-
-#else /* !HAVE_MISYNCSHM_H */
-
-Bool
-amdgpu_sync_init(ScreenPtr screen)
-{
-	xf86DrvMsg(xf86ScreenToScrn(screen)->scrnIndex, X_INFO,
-		   "SYNC extension fences disabled because misyncshm.h not "
-		   "available at build time\n");
-
-	return FALSE;
-}
-
-void
-amdgpu_sync_close(ScreenPtr screen)
-{
-}
-
-#endif


### PR DESCRIPTION
It's always present, no matter whether MIT sync fencing is actually enabled in the Xserver (we're checking that at rnutime).