### PR TITLE
configure.ac: make xorgproto >= 7.1 mandatory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,10 +77,7 @@ PKG_CHECK_MODULES(GBM, [gbm])
 
 # Obtain compiler/linker options for the driver dependencies
 PKG_CHECK_MODULES(XORG, [xorg-server >= 1.18 xproto fontsproto xf86driproto $REQUIRED_MODULES])
-PKG_CHECK_MODULES(XEXT, [xextproto >= 7.0.99.1],
-                  HAVE_XEXTPROTO_71="yes"; AC_DEFINE(HAVE_XEXTPROTO_71, 1, [xextproto 7.1 available]),
-                  HAVE_XEXTPROTO_71="no")
-AM_CONDITIONAL(HAVE_XEXTPROTO_71, [ test "$HAVE_XEXTPROTO_71" = "yes" ])
+PKG_CHECK_MODULES(XEXT, [xextproto >= 7.0.99.1])
 
 # Section "OutputClass" is only supported as of xserver 1.16
 PKG_CHECK_EXISTS([xorg-server >= 1.16],

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -52,14 +52,7 @@
 #include <present.h>
 #endif
 
-/* DPMS */
-#ifdef HAVE_XEXTPROTO_71
 #include <X11/extensions/dpmsconst.h>
-#else
-#define DPMS_SERVER
-#include <X11/extensions/dpms.h>
-#endif
-
 #include <X11/extensions/damageproto.h>
 
 #include "amdgpu_bo_helper.h"

--- a/src/amdgpu_video.c
+++ b/src/amdgpu_video.c
@@ -19,14 +19,7 @@
 #include "xf86.h"
 #include "dixstruct.h"
 
-/* DPMS */
-#ifdef HAVE_XEXTPROTO_71
 #include <X11/extensions/dpmsconst.h>
-#else
-#define DPMS_SERVER
-#include <X11/extensions/dpms.h>
-#endif
-
 #include <X11/extensions/Xv.h>
 #include "fourcc.h"
 

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -49,13 +49,7 @@
 #include "amdgpu_glamor.h"
 #include "amdgpu_pixmap.h"
 
-/* DPMS */
-#ifdef HAVE_XEXTPROTO_71
 #include <X11/extensions/dpmsconst.h>
-#else
-#define DPMS_SERVER
-#include <X11/extensions/dpms.h>
-#endif
 
 #include <gbm.h>
 


### PR DESCRIPTION
No need keep special hacks for such ancient xproto version.