### PR TITLE
drop using glamor_glyphs_init() on old Xservers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,12 +129,6 @@ if test "x$GLAMOR" != "xno"; then
 			      [#include "xorg-server.h"
 			       #include "glamor.h"])
 
-		AC_CHECK_DECL(glamor_glyphs_init,
-			      [AC_DEFINE(HAVE_GLAMOR_GLYPHS_INIT, 1,
-					 [Have glamor_glyphs_init API])], [],
-			      [#include "xorg-server.h"
-			       #include "glamor.h"])
-
 		AC_CHECK_DECL(glamor_egl_destroy_textured_pixmap,
 			      [AC_DEFINE(HAVE_GLAMOR_EGL_DESTROY_TEXTURED_PIXMAP, 1,
 					 [Have glamor_egl_destroy_textured_pixmap API])], [],

--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -64,11 +64,6 @@ Bool amdgpu_glamor_create_screen_resources(ScreenPtr screen)
 	if (!info->use_glamor)
 		return TRUE;
 
-#ifdef HAVE_GLAMOR_GLYPHS_INIT
-	if (!glamor_glyphs_init(screen))
-		return FALSE;
-#endif
-
 	return amdgpu_glamor_create_textured_pixmap(screen_pixmap,
 						    info->front_buffer);
 }


### PR DESCRIPTION
This function has been removed over a decade ago - no need to support such ancient Xserver versions anymore.