### PR TITLE
drop own copy of RegionDuplicate()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,12 +159,6 @@ else
 fi
 AM_CONDITIONAL(GLAMOR, test x$GLAMOR != xno)
 
-AC_CHECK_DECL(RegionDuplicate,
-	      [AC_DEFINE(HAVE_REGIONDUPLICATE, 1,
-	      [Have RegionDuplicate API])], [],
-	      [#include <xorg-server.h>
-	       #include <regionstr.h>])
-
 AC_CHECK_DECL(xf86CursorResetCursor,
 	      [AC_DEFINE(HAVE_XF86_CURSOR_RESET_CURSOR, 1,
 	      [Have xf86CursorResetCursor API])], [],

--- a/src/amdgpu_drv.h
+++ b/src/amdgpu_drv.h
@@ -89,25 +89,6 @@
 
 struct _SyncFence;
 
-#ifndef HAVE_REGIONDUPLICATE
-
-static inline RegionPtr
-RegionDuplicate(RegionPtr pOld)
-{
-	RegionPtr pNew;
-
-	pNew = RegionCreate(&pOld->extents, 0);
-	if (!pNew)
-		return NULL;
-	if (!RegionCopy(pNew, pOld)) {
-		RegionDestroy(pNew);
-		return NULL;
-	}
-	return pNew;
-}
-
-#endif
-
 #ifndef MAX
 #define MAX(a,b) ((a)>(b)?(a):(b))
 #endif


### PR DESCRIPTION
This function is present in the Xserver for way over a decade, so no need to carry around our own copy anymore.