### PR TITLE
drop checks for XF86_PDEV_SERVER_FD

### DIFF
--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -1818,11 +1818,9 @@ static Bool amdgpu_set_drm_master(ScrnInfoPtr pScrn)
 	AMDGPUEntPtr pAMDGPUEnt = AMDGPUEntPriv(pScrn);
 	int err;
 
-#ifdef XF86_PDEV_SERVER_FD
 	if (pAMDGPUEnt->platform_dev &&
 	    (pAMDGPUEnt->platform_dev->flags & XF86_PDEV_SERVER_FD))
 		return TRUE;
-#endif
 
 	err = drmSetMaster(pAMDGPUEnt->fd);
 	if (err)
@@ -1835,11 +1833,9 @@ static void amdgpu_drop_drm_master(ScrnInfoPtr pScrn)
 {
 	AMDGPUEntPtr pAMDGPUEnt = AMDGPUEntPriv(pScrn);
 
-#ifdef XF86_PDEV_SERVER_FD
 	if (pAMDGPUEnt->platform_dev &&
 	    (pAMDGPUEnt->platform_dev->flags & XF86_PDEV_SERVER_FD))
 		return;
-#endif
 
 	drmDropMaster(pAMDGPUEnt->fd);
 }

--- a/src/amdgpu_probe.c
+++ b/src/amdgpu_probe.c
@@ -177,7 +177,7 @@ static int amdgpu_kernel_open_fd(ScrnInfoPtr pScrn,
 
 void amdgpu_kernel_close_fd(AMDGPUEntPtr pAMDGPUEnt)
 {
-#if defined(XSERVER_PLATFORM_BUS) && defined(XF86_PDEV_SERVER_FD)
+#if defined(XSERVER_PLATFORM_BUS)
 	if (!(pAMDGPUEnt->platform_dev &&
 	      pAMDGPUEnt->platform_dev->flags & XF86_PDEV_SERVER_FD))
 #endif


### PR DESCRIPTION
It's always defined in the Xserver SDK since over a decade now. No need to keep workarounds for ancien Xserver versions.