### PR TITLE
configure.ac: drop check for present.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,12 +178,6 @@ AC_CHECK_DECL(GBM_BO_USE_FRONT_RENDERING,
 	      [#include <stdlib.h>
 	       #include <gbm.h>])
 
-AC_CHECK_HEADERS([present.h], [], [],
-		 [#include <X11/Xmd.h>
-		 #include <X11/Xproto.h>
-		 #include "xorg-server.h"
-		 #include <X11/X.h>])
-
 AC_CHECK_HEADERS([dri3.h], [], [],
 		 [#include <X11/Xmd.h>
 		 #include <xorg-server.h>])

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -48,9 +48,7 @@
 #include "shadow.h"
 #include <xf86Priv.h>
 
-#if HAVE_PRESENT_H
 #include <present.h>
-#endif
 
 #include <X11/extensions/dpmsconst.h>
 #include <X11/extensions/damageproto.h>

--- a/src/amdgpu_present.c
+++ b/src/amdgpu_present.c
@@ -29,8 +29,6 @@
 
 #include "amdgpu_drv.h"
 
-#ifdef HAVE_PRESENT_H
-
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -504,17 +502,3 @@ amdgpu_present_screen_init(ScreenPtr screen)
 
 	return TRUE;
 }
-
-#else /* !HAVE_PRESENT_H */
-
-Bool
-amdgpu_present_screen_init(ScreenPtr screen)
-{
-	xf86DrvMsg(xf86ScreenToScrn(screen)->scrnIndex, X_INFO,
-		   "Present extension disabled because present.h not available at "
-		   "build time\n");
-
-	return FALSE;
-}
-
-#endif


### PR DESCRIPTION
This header is always present, no matter whether present extension actually enabled. Thus no need to explicitly check for it.