### PR TITLE
drop checks on HAVE_CONFIG_H

### DIFF
--- a/src/amdgpu_bo_helper.c
+++ b/src/amdgpu_bo_helper.c
@@ -19,14 +19,11 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
+#include <xorg-server.h>
+
 #include <sys/mman.h>
 #include <gbm.h>
-
-#include <xorg-server.h>
 
 #include "amdgpu_drv.h"
 #include "amdgpu_bo_helper.h"

--- a/src/amdgpu_dri2.c
+++ b/src/amdgpu_dri2.c
@@ -25,10 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include "amdgpu_drv.h"

--- a/src/amdgpu_dri3.c
+++ b/src/amdgpu_dri3.c
@@ -20,12 +20,7 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
-
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include "amdgpu_drv.h"

--- a/src/amdgpu_drm_queue.c
+++ b/src/amdgpu_drm_queue.c
@@ -25,16 +25,10 @@
  *    Dave Airlie <airlied@redhat.com>
  *
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <errno.h>
-
-#include <xorg-server.h>
 #include <X11/Xdefs.h>
 #include <list.h>
 

--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -23,11 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #ifdef USE_GLAMOR

--- a/src/amdgpu_glamor_wrappers.c
+++ b/src/amdgpu_glamor_wrappers.c
@@ -26,12 +26,7 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
-
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
-
 #include <xorg-server.h>
 
 #include <fb.h>

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -24,10 +24,7 @@
  *    Dave Airlie <airlied@redhat.com>
  *
  */
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <errno.h>

--- a/src/amdgpu_misc.c
+++ b/src/amdgpu_misc.c
@@ -19,11 +19,7 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include "amdgpu_probe.h"

--- a/src/amdgpu_pixmap.c
+++ b/src/amdgpu_pixmap.c
@@ -21,11 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <xf86.h>

--- a/src/amdgpu_present.c
+++ b/src/amdgpu_present.c
@@ -20,11 +20,7 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include "amdgpu_drv.h"

--- a/src/amdgpu_probe.c
+++ b/src/amdgpu_probe.c
@@ -25,11 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <errno.h>

--- a/src/amdgpu_video.c
+++ b/src/amdgpu_video.c
@@ -1,8 +1,4 @@
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <stdlib.h>

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -24,11 +24,7 @@
  *    Dave Airlie <airlied@redhat.com>
  *
  */
-
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
-
 #include <xorg-server.h>
 
 #include <errno.h>


### PR DESCRIPTION
We always have config.h here, so no need for the extra check.