### PR TITLE
drop obsolete checks for dri3.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,10 +166,6 @@ AC_CHECK_DECL(GBM_BO_USE_FRONT_RENDERING,
 	      [#include <stdlib.h>
 	       #include <gbm.h>])
 
-AC_CHECK_HEADERS([dri3.h], [], [],
-		 [#include <X11/Xmd.h>
-		 #include <xorg-server.h>])
-
 CPPFLAGS="$SAVE_CPPFLAGS"
 
 # Checks for headers/macros for byte swapping

--- a/src/amdgpu_dri3.c
+++ b/src/amdgpu_dri3.c
@@ -25,8 +25,6 @@
 
 #include "amdgpu_drv.h"
 
-#ifdef HAVE_DRI3_H
-
 #include "amdgpu_glamor.h"
 #include "amdgpu_pixmap.h"
 #include "dri3.h"
@@ -241,17 +239,3 @@ amdgpu_dri3_screen_init(ScreenPtr screen)
 
 	return TRUE;
 }
-
-#else /* !HAVE_DRI3_H */
-
-Bool
-amdgpu_dri3_screen_init(ScreenPtr screen)
-{
-	xf86DrvMsg(xf86ScreenToScrn(screen)->scrnIndex, X_INFO,
-		   "Can't initialize DRI3 because dri3.h not available at "
-		   "build time\n");
-
-	return FALSE;
-}
-
-#endif


### PR DESCRIPTION
It's always present, no matter whether DRI3 is actually enabled. No need to care about ancient - pre-DRI3 - Xserver versions.