### PR TITLE
drop obsolete check for glamor_finish()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,13 +125,6 @@ if test "x$GLAMOR" != "xno"; then
 			      [GLAMOR_XSERVER="yes"], [GLAMOR_XSERVER="no"],
 			      [#include "xorg-server.h"
 			       #include "glamor.h"])
-
-		AC_CHECK_DECL(glamor_finish,
-			      [AC_DEFINE(HAVE_GLAMOR_FINISH, 1,
-					 [Have glamor_finish API])],
-					 [PKG_CHECK_MODULES(LIBGL, [gl])],
-			      [#include "xorg-server.h"
-			       #include "glamor.h"])
 	fi
 
 	if test "x$GLAMOR_XSERVER" != xyes; then

--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -36,10 +36,6 @@
 
 #include <gbm.h>
 
-#ifndef HAVE_GLAMOR_FINISH
-#include <GL/gl.h>
-#endif
-
 DevPrivateKeyRec amdgpu_pixmap_index;
 
 void amdgpu_glamor_exchange_buffers(PixmapPtr src, PixmapPtr dst)
@@ -468,13 +464,8 @@ void amdgpu_glamor_finish(ScrnInfoPtr pScrn)
 	AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
 
 	if (info->use_glamor) {
-#if HAVE_GLAMOR_FINISH
 		glamor_finish(pScrn->pScreen);
 		info->gpu_flushed++;
-#else
-		amdgpu_glamor_flush(pScrn);
-		glFinish();
-#endif
 	}
 }
 


### PR DESCRIPTION
This function is always present since about a decade ago, so no need to check for it and having a fallback.