### PR TITLE
configure.ac: drop checking for xf86CursorResetCursor()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,12 +144,6 @@ else
 fi
 AM_CONDITIONAL(GLAMOR, test x$GLAMOR != xno)
 
-AC_CHECK_DECL(xf86CursorResetCursor,
-	      [AC_DEFINE(HAVE_XF86_CURSOR_RESET_CURSOR, 1,
-	      [Have xf86CursorResetCursor API])], [],
-	      [#include <xorg-server.h>
-	       #include <xf86Cursor.h>])
-
 AC_CHECK_DECL(GBM_BO_USE_LINEAR,
 	      [AC_DEFINE(HAVE_GBM_BO_USE_LINEAR, 1, [Have GBM_BO_USE_LINEAR])], [],
 	      [#include <stdlib.h>

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -1381,11 +1381,6 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
 		break;
 	}
 
-#ifndef HAVE_XF86_CURSOR_RESET_CURSOR
-	if (!info->hwcursor_disabled)
-		xf86_reload_cursors(pScreen);
-#endif
-
 done:
 	if (!ret) {
 		crtc->x = saved_x;
@@ -1674,11 +1669,7 @@ drmmode_crtc_gamma_set(xf86CrtcPtr crtc, uint16_t * red, uint16_t * green,
 	if (info->hwcursor_disabled & (1 << i))
 		return;
 
-#ifdef HAVE_XF86_CURSOR_RESET_CURSOR
 	xf86CursorResetCursor(scrn->pScreen);
-#else
-	xf86_reload_cursors(scrn->pScreen);
-#endif
 }
 
 static Bool drmmode_set_scanout_pixmap(xf86CrtcPtr crtc, PixmapPtr ppix)


### PR DESCRIPTION
This function is always present for about a decade now, so no need to check for it (and having a fallback) anymore.