### PR TITLE
configure.ac: no need to check for GLAMOR_NO_DRI3 and old libglamor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,18 +119,6 @@ AC_ARG_ENABLE(glamor,
 
 if test "x$GLAMOR" != "xno"; then
 	AC_CHECK_HEADERS([glamor.h], [GLAMOR_H="yes"], [GLAMOR_H="no"], [#include "xorg-server.h"])
-
-	if test "x$GLAMOR_H" = xyes; then
-		AC_CHECK_DECL(GLAMOR_NO_DRI3,
-			      [GLAMOR_XSERVER="yes"], [GLAMOR_XSERVER="no"],
-			      [#include "xorg-server.h"
-			       #include "glamor.h"])
-	fi
-
-	if test "x$GLAMOR_XSERVER" != xyes; then
-		PKG_CHECK_MODULES(LIBGLAMOR, [glamor >= 0.6.0])
-		PKG_CHECK_MODULES(LIBGLAMOR_EGL, [glamor-egl])
-	fi
 	AC_DEFINE(USE_GLAMOR, 1, [Enable glamor acceleration])
 else
 	AC_MSG_RESULT([$GLAMOR])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,8 +49,6 @@ amdgpu_drv_la_SOURCES = \
 	amdgpu_misc.c amdgpu_probe.c \
 	$(AMDGPU_KMS_SRCS)
 
-AM_CFLAGS += @LIBGLAMOR_CFLAGS@
-amdgpu_drv_la_LIBADD += @LIBGLAMOR_LIBS@
 amdgpu_drv_la_SOURCES += \
 	amdgpu_glamor.c \
 	amdgpu_glamor_wrappers.c \


### PR DESCRIPTION
This symbol is always present for over a decade ago, so no need to check for it. And so we also don't need any support for old external libglamor anymore.