### PR TITLE
drop workarounds for ancient mesa

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,11 +137,6 @@ else
 fi
 AM_CONDITIONAL(GLAMOR, test x$GLAMOR != xno)
 
-AC_CHECK_DECL(GBM_BO_USE_FRONT_RENDERING,
-	      [AC_DEFINE(HAVE_GBM_BO_USE_FRONT_RENDERING, 1, [Have GBM_BO_USE_FRONT_RENDERING])], [],
-	      [#include <stdlib.h>
-	       #include <gbm.h>])
-
 AC_CHECK_HEADERS([dri3.h], [], [],
 		 [#include <X11/Xmd.h>
 		 #include <xorg-server.h>])

--- a/configure.ac
+++ b/configure.ac
@@ -137,11 +137,6 @@ else
 fi
 AM_CONDITIONAL(GLAMOR, test x$GLAMOR != xno)
 
-AC_CHECK_DECL(GBM_BO_USE_LINEAR,
-	      [AC_DEFINE(HAVE_GBM_BO_USE_LINEAR, 1, [Have GBM_BO_USE_LINEAR])], [],
-	      [#include <stdlib.h>
-	       #include <gbm.h>])
-
 AC_CHECK_DECL(GBM_BO_USE_FRONT_RENDERING,
 	      [AC_DEFINE(HAVE_GBM_BO_USE_FRONT_RENDERING, 1, [Have GBM_BO_USE_FRONT_RENDERING])], [],
 	      [#include <stdlib.h>

--- a/src/amdgpu_bo_helper.c
+++ b/src/amdgpu_bo_helper.c
@@ -82,10 +82,8 @@ struct amdgpu_buffer *amdgpu_alloc_pixmap_bo(ScrnInfoPtr pScrn, int width,
 		if (usage_hint & AMDGPU_CREATE_PIXMAP_SCANOUT)
 			bo_use |= GBM_BO_USE_SCANOUT;
 
-#ifdef HAVE_GBM_BO_USE_FRONT_RENDERING
 		if (usage_hint & AMDGPU_CREATE_PIXMAP_FRONT)
 			bo_use |= GBM_BO_USE_FRONT_RENDERING;
-#endif
 
 		if (usage_hint == CREATE_PIXMAP_USAGE_SHARED ||
 		    (usage_hint & AMDGPU_CREATE_PIXMAP_LINEAR)) {

--- a/src/amdgpu_bo_helper.c
+++ b/src/amdgpu_bo_helper.c
@@ -87,12 +87,10 @@ struct amdgpu_buffer *amdgpu_alloc_pixmap_bo(ScrnInfoPtr pScrn, int width,
 			bo_use |= GBM_BO_USE_FRONT_RENDERING;
 #endif
 
-#ifdef HAVE_GBM_BO_USE_LINEAR
 		if (usage_hint == CREATE_PIXMAP_USAGE_SHARED ||
 		    (usage_hint & AMDGPU_CREATE_PIXMAP_LINEAR)) {
 			bo_use |= GBM_BO_USE_LINEAR;
 		}
-#endif
 
 		pixmap_buffer->bo.gbm = gbm_bo_create(info->gbm, width, height,
 						      gbm_format,

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -1325,13 +1325,11 @@ static Bool AMDGPUPreInitAccel_KMS(ScrnInfoPtr pScrn)
 	if (xf86ReturnOptValBool(info->Options, OPTION_ACCEL, TRUE)) {
 		AMDGPUEntPtr pAMDGPUEnt = AMDGPUEntPriv(pScrn);
 		Bool use_glamor = TRUE;
-#ifdef HAVE_GBM_BO_USE_LINEAR
 		const char *accel_method;
 
 		accel_method = xf86GetOptValString(info->Options, OPTION_ACCEL_METHOD);
 		if ((accel_method && !strcmp(accel_method, "none")))
 			use_glamor = FALSE;
-#endif
 
 #ifdef DRI2
 		info->dri2.available = ! !xf86LoadSubModule(pScrn, "dri2");


### PR DESCRIPTION
Don't check for symbols that had been introduced very long time ago, anymore. Just rely on mesa not being too ancient.