### PR TITLE
drmmode_display: fix missing include of dpmsconst.h

### DIFF
--- a/src/drmmode_display.h
+++ b/src/drmmode_display.h
@@ -32,6 +32,8 @@
 #include "libudev.h"
 #endif
 
+#include <X11/extensions/dpmsconst.h>
+
 #include "amdgpu_drm_queue.h"
 #include "amdgpu_probe.h"
 #include "amdgpu.h"


### PR DESCRIPTION
Don't rely on some Xserver SDK header is silently doing it by accident.