### PR TITLE
don't crash server on malloc fail (XNFasprintf)

### DIFF
--- a/src/amdgpu_probe.c
+++ b/src/amdgpu_probe.c
@@ -123,8 +123,11 @@ static int amdgpu_kernel_open_fd(ScrnInfoPtr pScrn,
 	else
 		dev = pci_dev;
 
-	XNFasprintf(&pAMDGPUEnt->busid, "pci:%04x:%02x:%02x.%u",
-		    dev->domain, dev->bus, dev->dev, dev->func);
+	if (asprintf(&pAMDGPUEnt->busid, "pci:%04x:%02x:%02x.%u",
+		    dev->domain, dev->bus, dev->dev, dev->func) == -1) {
+		xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "[drm] malloc failed\n");
+		return -1;
+	}
 
 	if (platform_dev) {
 		fd = xf86_get_platform_device_int_attrib(platform_dev,

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -3283,7 +3283,11 @@ Bool drmmode_pre_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, int cpp)
 	/* workout clones */
 	drmmode_clones_init(pScrn, drmmode, mode_res);
 
-	XNFasprintf(&provider_name, "%s @ %s", pScrn->chipset, pAMDGPUEnt->busid);
+	if (asprintf(&provider_name, "%s @ %s", pScrn->chipset, pAMDGPUEnt->busid) == -1) {
+		xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "malloc failed\n");
+		return FALSE;
+	}
+
 	xf86ProviderSetup(pScrn, NULL, provider_name);
 	free(provider_name);
 


### PR DESCRIPTION
Use standard libc asprintf() instead of XNFasprintf().