### PR TITLE
Add missing xorg-server.h header

### DIFF
--- a/src/amdgpu_drv.h
+++ b/src/amdgpu_drv.h
@@ -40,6 +40,7 @@
 #include <stdlib.h>		/* For abs() */
 #include <unistd.h>		/* For usleep() */
 #include <sys/time.h>		/* For gettimeofday() */
+#include <xorg-server.h>
 
 #include "config.h"
 

--- a/src/amdgpu_glamor.h
+++ b/src/amdgpu_glamor.h
@@ -27,6 +27,7 @@
 #ifndef AMDGPU_GLAMOR_H
 #define AMDGPU_GLAMOR_H
 
+#include <xorg-server.h>
 #include "xf86xv.h"
 
 #ifdef USE_GLAMOR


### PR DESCRIPTION
This should be added by the source file, not the build system.