### PR TITLE
(master) configure.ac: replace deprecated AC_PROG_LIBTOOL by LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ XORG_DEFAULT_OPTIONS
 
 # Initialize libtool
 AC_DISABLE_STATIC
-AC_PROG_LIBTOOL
+LT_INIT
 
 # Checks for programs.
 AM_PROG_CC_C_O


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
