### PR TITLE
(master) admgpu_dri3: conditional build of amdgpu_dri3_get_drawable_modifiers()

### DIFF
--- a/src/amdgpu_dri3.c
+++ b/src/amdgpu_dri3.c
@@ -925,7 +925,9 @@ amdgpu_dri3_get_modifiers(ScreenPtr screen, uint32_t format,
 	return count;
 }
 
-static Bool
+#ifdef GBM_BO_WITH_MODIFIERS
+
+Bool
 amdgpu_dri3_get_drawable_modifiers(DrawablePtr draw, uint32_t format,
 				   uint32_t *num_modifiers, uint64_t **modifiers)
 {
@@ -1008,6 +1010,7 @@ amdgpu_dri3_get_drawable_modifiers(DrawablePtr draw, uint32_t format,
 
 	return TRUE;
 }
+#endif /* GBM_BO_WITH_MODIFIERS */
 
 static dri3_screen_info_rec amdgpu_dri3_screen_info = {
 	.version = 4,


### PR DESCRIPTION
It's only used when GBM_BO_WITH_MODIFIERS is defined, so build it only then.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
