### PR TITLE
amdgpu glamor: fix module loading when linked with '-z now'

### DIFF
--- a/src/amdgpu_bo_helper.c
+++ b/src/amdgpu_bo_helper.c
@@ -209,7 +209,7 @@ Bool amdgpu_pixmap_get_handle(PixmapPtr pixmap, uint32_t *handle)
 		CARD32 size;
 		int fd, r;
 
-		fd = glamor_fd_from_pixmap(screen, pixmap, &stride, &size);
+        fd = info->glamor_abi.fd_from_pixmap(screen, pixmap, &stride, &size);
 		if (fd < 0)
 			return FALSE;
 

--- a/src/amdgpu_dri3.c
+++ b/src/amdgpu_dri3.c
@@ -468,10 +468,11 @@ static PixmapPtr amdgpu_dri3_pixmap_from_fd(ScreenPtr screen,
 					    CARD8 bpp)
 {
 	PixmapPtr pixmap;
+    AMDGPUInfoPtr info = AMDGPUPTR(xf86ScreenToScrn(screen));
 
 	/* Avoid generating a GEM flink name if possible */
-	if (AMDGPUPTR(xf86ScreenToScrn(screen))->use_glamor) {
-		pixmap = glamor_pixmap_from_fd(screen, fd, width, height,
+    if (info->use_glamor) {
+        pixmap =  info->glamor_abi.pixmap_from_fd(screen, fd, width, height,
 					       stride, depth, bpp);
 		if (pixmap) {
 			struct amdgpu_pixmap *priv = calloc(1, sizeof(*priv));
@@ -564,8 +565,8 @@ static PixmapPtr amdgpu_dri3_pixmap_from_fds(ScreenPtr screen,
 	if (!info->use_glamor)
 		goto non_glamor_path;
 
-	/* glamor path: use GBM to import multi-plane buffers */
-	gbm = glamor_egl_get_gbm_device(screen);
+    /* glamor path: use GBM to import multi-plane buffers */
+    gbm = info->glamor_abi.egl_get_gbm_device(screen);
 	if (!gbm)
 		goto non_glamor_path;
 
@@ -615,7 +616,7 @@ static PixmapPtr amdgpu_dri3_pixmap_from_fds(ScreenPtr screen,
 
 	if (bo) {
 		screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, strides[0], NULL);
-		ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, FALSE);
+        ret = info->glamor_abi.egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, FALSE);
 		gbm_bo_destroy(bo);
 		if (ret) {
 			struct amdgpu_pixmap *priv = calloc(1, sizeof(*priv));
@@ -684,7 +685,7 @@ static int amdgpu_dri3_fd_from_pixmap(ScreenPtr screen,
 	AMDGPUInfoPtr info = AMDGPUPTR(scrn);
 
 	if (info->use_glamor) {
-		int ret = glamor_fd_from_pixmap(screen, pixmap, stride, size);
+        int ret = info->glamor_abi.fd_from_pixmap(screen, pixmap, stride, size);
 
 		/* Any pending drawing operations need to be flushed to the
 		 * kernel driver before the client starts using the pixmap
@@ -734,7 +735,7 @@ static int amdgpu_dri3_fds_from_pixmap(ScreenPtr screen,
 		CARD32 size;
 		int ret;
 
-		ret = glamor_fd_from_pixmap(screen, pixmap, &stride16, &size);
+        ret = info->glamor_abi.fd_from_pixmap(screen, pixmap, &stride16, &size);
 		if (ret < 0)
 			return -1;
 

--- a/src/amdgpu_drv.h
+++ b/src/amdgpu_drv.h
@@ -78,6 +78,9 @@
 #include "drmmode_display.h"
 #include "amdgpu_bo_helper.h"
 
+#include "glamor.h"
+#include "shadow.h"
+
 struct _SyncFence;
 
 #ifndef MAX
@@ -285,6 +288,54 @@ typedef struct {
 		SharePixmapBackingProcPtr SavedSharePixmapBacking;
 		SetSharedPixmapBackingProcPtr SavedSetSharedPixmapBacking;
 	} glamor;
+
+    /* glamor API */
+    struct {
+
+        PixmapPtr (*create_pixmap) (ScreenPtr,int,int, int, unsigned int);
+
+        Bool (*back_pixmap_from_fd)(PixmapPtr, int, CARD16, CARD16, CARD16,
+                                    CARD8, CARD8);
+        void (*block_handler)(ScreenPtr);
+        /* void (*clear_pixmap)(PixmapPtr); */
+        Bool (*egl_create_textured_pixmap)(PixmapPtr, int, int);
+        Bool (*egl_create_textured_pixmap_from_gbm_bo)(PixmapPtr,
+                                                       struct gbm_bo *,
+                                                       Bool);
+        void (*egl_exchange_buffers)(PixmapPtr, PixmapPtr);
+        struct gbm_device *(*egl_get_gbm_device)(ScreenPtr);
+        Bool (*egl_init)(ScrnInfoPtr, int);
+        void (*finish)(ScreenPtr);
+        /* struct gbm_bo *(*gbm_bo_from_pixmap)(ScreenPtr, PixmapPtr); */
+        Bool (*init)(ScreenPtr, unsigned int);
+        /* int (*name_from_pixmap)(PixmapPtr, CARD16 *, CARD32 *); */
+        /* void (*set_drawable_modifiers_func)(ScreenPtr,
+                                            GetDrawableModifiersFuncPtr); */
+        /* int (*shareable_fd_from_pixmap)(ScreenPtr, PixmapPtr, CARD16 *,
+                                        CARD32 *); */
+        /* Bool (*supports_pixmap_import_export)(ScreenPtr); */
+        XF86VideoAdaptorPtr (*xv_init)(ScreenPtr, int);
+        /* const char *(*egl_get_driver_name)(ScreenPtr); */
+
+        int (*fd_from_pixmap)(ScreenPtr, PixmapPtr, CARD16 *, CARD32 *);
+        void (*validate_gc)  (GCPtr, unsigned long, DrawablePtr);
+
+        /* PixmapPtr (*pixmap_from_fds)(ScreenPtr, CARD8,const int *,CARD16,CARD16,const CARD32 *,const CARD32 *,CARD8,CARD8,uint64_t); */
+        PixmapPtr (*pixmap_from_fd)(ScreenPtr,int,CARD16,CARD16,CARD16,CARD8,CARD8);
+
+
+    } glamor_abi;
+
+    /* shadow API */
+    struct {
+        Bool (*Setup)(ScreenPtr);
+        Bool (*Add)(ScreenPtr, PixmapPtr, ShadowUpdateProc, ShadowWindowProc,
+                    int, void *);
+        /* void (*Remove)(ScreenPtr, PixmapPtr); */
+        /* void (*Update32to24)(ScreenPtr, shadowBufPtr); */
+        void (*UpdatePacked)(ScreenPtr, shadowBufPtr);
+    } shadow_abi;
+
 
 	xf86CrtcFuncsRec drmmode_crtc_funcs;
 } AMDGPUInfoRec, *AMDGPUInfoPtr;

--- a/src/amdgpu_glamor.c
+++ b/src/amdgpu_glamor.c
@@ -42,7 +42,7 @@ void amdgpu_glamor_exchange_buffers(PixmapPtr src, PixmapPtr dst)
 
 	if (!info->use_glamor)
 		return;
-	glamor_egl_exchange_buffers(src, dst);
+	info->glamor_abi.egl_exchange_buffers(src, dst);
 }
 
 Bool amdgpu_glamor_create_screen_resources(ScreenPtr screen)
@@ -72,7 +72,7 @@ Bool amdgpu_glamor_pre_init(ScrnInfoPtr scrn)
 	}
 
 	/* Load glamor module */
-	if ((glamor_module = xf86LoadSubModule(scrn, GLAMOR_EGL_MODULE_NAME))) {
+    if ((glamor_module = xf86LoadSubModule(scrn, "glamoregl"))) {
 		version = xf86GetModuleVersion(glamor_module);
 		if (version < MODULE_VERSION_NUMERIC(0, 3, 1)) {
 			xf86DrvMsg(scrn->scrnIndex, X_ERROR,
@@ -89,7 +89,7 @@ Bool amdgpu_glamor_pre_init(ScrnInfoPtr scrn)
 				return FALSE;
 			}
 
-			if (glamor_egl_init(scrn, pAMDGPUEnt->fd)) {
+            if (info->glamor_abi.egl_init(scrn, pAMDGPUEnt->fd)) {
 				xf86DrvMsg(scrn->scrnIndex, X_INFO,
 					   "glamor detected, initialising EGL layer.\n");
 			} else {
@@ -118,7 +118,7 @@ amdgpu_glamor_create_textured_pixmap(PixmapPtr pixmap, struct amdgpu_buffer *bo)
 		return TRUE;
 
 	if (bo->flags & AMDGPU_BO_FLAGS_GBM) {
-		return glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap,
+        return info->glamor_abi.egl_create_textured_pixmap_from_gbm_bo(pixmap,
 								     bo->bo.gbm,
 								     FALSE);
 	} else {
@@ -127,7 +127,7 @@ amdgpu_glamor_create_textured_pixmap(PixmapPtr pixmap, struct amdgpu_buffer *bo)
 		if (!amdgpu_bo_get_handle(bo, &bo_handle))
 			return FALSE;
 
-		return glamor_egl_create_textured_pixmap(pixmap, bo_handle,
+        return info->glamor_abi.egl_create_textured_pixmap(pixmap, bo_handle,
 							 pixmap->devKind);
 	}
 }
@@ -188,7 +188,7 @@ amdgpu_glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
 			usage |= AMDGPU_CREATE_PIXMAP_LINEAR |
 				 AMDGPU_CREATE_PIXMAP_GTT;
 		} else if (usage != CREATE_PIXMAP_USAGE_BACKING_PIXMAP) {
-			pixmap = glamor_create_pixmap(screen, w, h, depth, usage);
+			pixmap = info->glamor_abi.create_pixmap(screen, w, h, depth, usage);
 			if (pixmap)
 				return pixmap;
 		}
@@ -253,7 +253,7 @@ fallback_glamor:
 	 * texture only pixmap and will never fallback to DDX layer
 	 * afterwards.
 	 */
-	new_pixmap = glamor_create_pixmap(screen, w, h, depth, usage);
+	new_pixmap = info->glamor_abi.create_pixmap(screen, w, h, depth, usage);
 	amdgpu_bo_unref(&priv->bo);
 fallback_priv:
 	free(priv);
@@ -271,6 +271,10 @@ amdgpu_glamor_set_pixmap_bo(DrawablePtr drawable, PixmapPtr pixmap)
 	PixmapPtr old = get_drawable_pixmap(drawable);
 	ScreenPtr screen = drawable->pScreen;
 	struct amdgpu_pixmap *priv = amdgpu_get_pixmap_private(pixmap);
+
+	ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
+        AMDGPUInfoPtr info = AMDGPUPTR(scrn);
+
 	GCPtr gc;
 
 	/* With a glamor pixmap, 2D pixmaps are created in texture
@@ -297,7 +301,7 @@ amdgpu_glamor_set_pixmap_bo(DrawablePtr drawable, PixmapPtr pixmap)
 	}
 
 	/* And redirect the pixmap to the new bo (for 3D). */
-	glamor_egl_exchange_buffers(old, pixmap);
+	info->glamor_abi.egl_exchange_buffers(old, pixmap);
 	amdgpu_set_pixmap_private(pixmap, amdgpu_get_pixmap_private(old));
 	amdgpu_set_pixmap_private(old, priv);
 
@@ -358,7 +362,7 @@ amdgpu_glamor_share_pixmap_backing(PixmapPtr pixmap, ScreenPtr secondary,
 		amdgpu_glamor_set_pixmap_bo(&pixmap->drawable, linear);
 	}
 
-	fd = glamor_fd_from_pixmap(screen, pixmap, &stride, &size);
+	fd = info->glamor_abi.fd_from_pixmap(screen, pixmap, &stride, &size);
 	if (fd < 0)
 		return FALSE;
 
@@ -413,7 +417,7 @@ Bool amdgpu_glamor_init(ScreenPtr screen)
 		}
 	}
 
-	if (!glamor_init(screen, GLAMOR_USE_EGL_SCREEN | GLAMOR_USE_SCREEN |
+    if (!info->glamor_abi.init(screen, GLAMOR_USE_EGL_SCREEN | GLAMOR_USE_SCREEN |
 			 GLAMOR_USE_PICTURE_SCREEN | GLAMOR_INVERTED_Y_AXIS |
 			 GLAMOR_NO_DRI3)) {
 		xf86DrvMsg(scrn->scrnIndex, X_ERROR,
@@ -452,7 +456,7 @@ void amdgpu_glamor_flush(ScrnInfoPtr pScrn)
 	AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
 
 	if (info->use_glamor) {
-		glamor_block_handler(pScrn->pScreen);
+        info->glamor_abi.block_handler(pScrn->pScreen);
 	}
 
 	info->gpu_flushed++;
@@ -463,7 +467,7 @@ void amdgpu_glamor_finish(ScrnInfoPtr pScrn)
 	AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
 
 	if (info->use_glamor) {
-		glamor_finish(pScrn->pScreen);
+        info->glamor_abi.finish(pScrn->pScreen);
 		info->gpu_flushed++;
 	}
 }
@@ -484,5 +488,7 @@ amdgpu_glamor_fini(ScreenPtr screen)
 
 XF86VideoAdaptorPtr amdgpu_glamor_xv_init(ScreenPtr pScreen, int num_adapt)
 {
-	return glamor_xv_init(pScreen, num_adapt);
+    ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
+    AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
+    return info->glamor_abi.xv_init(pScreen, num_adapt);
 }

--- a/src/amdgpu_glamor.h
+++ b/src/amdgpu_glamor.h
@@ -73,12 +73,7 @@ PixmapPtr amdgpu_glamor_set_pixmap_bo(DrawablePtr drawable, PixmapPtr pixmap);
 
 XF86VideoAdaptorPtr amdgpu_glamor_xv_init(ScreenPtr pScreen, int num_adapt);
 
-/* glamor_fds_from_pixmap declaration - only available when DRI3 is enabled */
-#ifndef GLAMOR_NO_DRI3
-extern int glamor_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
-                                  uint32_t *strides, uint32_t *offsets,
-                                  uint64_t *modifier);
-#endif
+
 
 /* DRI3 drawable modifiers callback */
 #ifdef GBM_BO_WITH_MODIFIERS

--- a/src/amdgpu_glamor_wrappers.c
+++ b/src/amdgpu_glamor_wrappers.c
@@ -615,7 +615,7 @@ amdgpu_glamor_validate_gc(GCPtr pGC, unsigned long changes, DrawablePtr pDrawabl
 	ScrnInfoPtr scrn = xf86ScreenToScrn(pGC->pScreen);
 	AMDGPUInfoPtr info = AMDGPUPTR(scrn);
 
-	glamor_validate_gc(pGC, changes, pDrawable);
+    info->glamor_abi.validate_gc(pGC, changes, pDrawable);
 	info->glamor.SavedCopyArea = pGC->ops->CopyArea;
 	info->glamor.SavedPolyFillRect = pGC->ops->PolyFillRect;
 

--- a/src/amdgpu_kms.c
+++ b/src/amdgpu_kms.c
@@ -50,10 +50,14 @@
 #include <X11/extensions/dpmsconst.h>
 #include <X11/extensions/damageproto.h>
 
+#include "glamor.h"
+
 #include "amdgpu_bo_helper.h"
 #include "amdgpu_pixmap.h"
 
+
 #include <gbm.h>
+
 
 static DevPrivateKeyRec amdgpu_window_private_key;
 static DevScreenPrivateKeyRec amdgpu_client_private_key;
@@ -64,6 +68,8 @@ static Bool amdgpu_property_vectors_wrapped;
 static Bool restore_property_vector;
 static int (*saved_change_property) (ClientPtr client);
 static int (*saved_delete_property) (ClientPtr client);
+
+static bool load_glamor(ScrnInfoPtr pScrn);
 
 static Bool amdgpu_setup_kernel_mem(ScreenPtr pScreen);
 
@@ -299,7 +305,10 @@ static void *amdgpuShadowWindow(ScreenPtr screen, CARD32 row, CARD32 offset,
 static void
 amdgpuUpdatePacked(ScreenPtr pScreen, shadowBufPtr pBuf)
 {
-	shadowUpdatePacked(pScreen, pBuf);
+    ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
+    AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
+
+    info->shadow_abi.UpdatePacked(pScreen, pBuf);
 }
 
 static Bool
@@ -392,7 +401,7 @@ static Bool AMDGPUCreateScreenResources_KMS(ScreenPtr pScreen)
 	if (info->shadow_fb) {
 		pixmap = pScreen->GetScreenPixmap(pScreen);
 
-		if (!shadowAdd(pScreen, pixmap, amdgpuUpdatePacked,
+        if (!info->shadow_abi.Add(pScreen, pixmap, amdgpuUpdatePacked,
 			       amdgpuShadowWindow, 0, NULL))
 			return FALSE;
 	}
@@ -1328,6 +1337,15 @@ static Bool AMDGPUPreInitAccel_KMS(ScrnInfoPtr pScrn)
 		info->dri2.available = ! !xf86LoadSubModule(pScrn, "dri2");
 #endif
 
+                if (use_glamor) {
+                    if (!load_glamor(pScrn)){
+                        use_glamor = FALSE;
+
+			xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
+					   "amdgpu_glamor_pre_init failed "
+					   "to load glamor submodule\n");
+		    }
+		}
 		if (info->dri2.available)
 			info->gbm = gbm_create_device(pAMDGPUEnt->fd);
 
@@ -1896,6 +1914,69 @@ static Bool AMDGPUCloseScreen_KMS(ScreenPtr pScreen)
 	return pScreen->CloseScreen(pScreen);
 }
 
+/**
+ * @brief load_glamor load glamor functions
+ * @param pScrn
+ */
+static bool
+load_glamor(ScrnInfoPtr pScrn)
+{
+    void *mod = xf86LoadSubModule(pScrn, "glamoregl");
+    AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
+
+
+    if (!mod)
+        return false;
+
+    info->glamor_abi.create_pixmap = LoaderSymbolFromModule(mod,"glamor_create_pixmap");
+    info->glamor_abi.back_pixmap_from_fd = LoaderSymbolFromModule(mod, "glamor_back_pixmap_from_fd");
+    info->glamor_abi.block_handler = LoaderSymbolFromModule(mod, "glamor_block_handler");
+    /* info->glamor_abi.clear_pixmap = LoaderSymbolFromModule(mod, "glamor_clear_pixmap"); */
+    info->glamor_abi.egl_create_textured_pixmap = LoaderSymbolFromModule(mod, "glamor_egl_create_textured_pixmap");
+    info->glamor_abi.egl_create_textured_pixmap_from_gbm_bo = LoaderSymbolFromModule(mod, "glamor_egl_create_textured_pixmap_from_gbm_bo");
+    info->glamor_abi.egl_exchange_buffers = LoaderSymbolFromModule(mod, "glamor_egl_exchange_buffers"); 
+    info->glamor_abi.egl_get_gbm_device = LoaderSymbolFromModule(mod, "glamor_egl_get_gbm_device");
+    info->glamor_abi.egl_init = LoaderSymbolFromModule(mod, "glamor_egl_init");
+    info->glamor_abi.finish = LoaderSymbolFromModule(mod, "glamor_finish");
+    /*
+    info->glamor_abi.gbm_bo_from_pixmap = LoaderSymbolFromModule(mod, "glamor_gbm_bo_from_pixmap");
+    */
+    info->glamor_abi.init = LoaderSymbolFromModule(mod, "glamor_init");
+    /*
+    info->glamor_abi.name_from_pixmap = LoaderSymbolFromModule(mod, "glamor_name_from_pixmap");
+    info->glamor_abi.set_drawable_modifiers_func = LoaderSymbolFromModule(mod, "glamor_set_drawable_modifiers_func");
+    info->glamor_abi.shareable_fd_from_pixmap = LoaderSymbolFromModule(mod, "glamor_shareable_fd_from_pixmap");
+    info->glamor_abi.supports_pixmap_import_export = LoaderSymbolFromModule(mod, "glamor_supports_pixmap_import_export");
+    info->glamor_abi.egl_get_driver_name = LoaderSymbolFromModule(mod, "glamor_egl_get_driver_name");
+     */
+    info->glamor_abi.xv_init = LoaderSymbolFromModule(mod, "glamor_xv_init");
+    info->glamor_abi.fd_from_pixmap = LoaderSymbolFromModule(mod, "glamor_fd_from_pixmap");
+    info->glamor_abi.validate_gc = LoaderSymbolFromModule(mod, "glamor_validate_gc");
+    return TRUE;
+}
+
+static bool
+load_shadowfd(ScrnInfoPtr pScrn){
+
+    void *mod = xf86LoadSubModule(pScrn, "shadow");
+    AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
+
+    if (!mod){
+        return false;
+    }
+
+    info->shadow_abi.Setup        = LoaderSymbolFromModule(mod, "shadowSetup");
+    info->shadow_abi.Add          = LoaderSymbolFromModule(mod, "shadowAdd");
+    /*
+    info->shadow_abi.Remove       = LoaderSymbolFromModule(mod, "shadowRemove");
+    info->shadow_abi.Update32to24 = LoaderSymbolFromModule(mod, "shadowUpdate32to24");
+     */
+    info->shadow_abi.UpdatePacked = LoaderSymbolFromModule(mod, "shadowUpdatePacked");
+
+    return true;
+}
+
+
 void AMDGPUFreeScreen_KMS(ScrnInfoPtr pScrn)
 {
 	xf86DrvMsgVerb(pScrn->scrnIndex, X_INFO, AMDGPU_LOGLEVEL_DEBUG,
@@ -2038,8 +2119,9 @@ Bool AMDGPUScreenInit_KMS(ScreenPtr pScreen, int argc, char **argv)
 		if (amdgpu_glamor_init(pScreen)) {
 			xf86DrvMsg(pScrn->scrnIndex, X_INFO,
 				   "Acceleration enabled\n");
+
 #ifdef GBM_BO_WITH_MODIFIERS
-			glamor_set_drawable_modifiers_func(pScreen,
+            info->glamor_abi.set_drawable_modifiers_func(pScreen,
 				                                amdgpu_dri3_get_drawable_modifiers);
 #endif
 		} else {
@@ -2080,7 +2162,13 @@ Bool AMDGPUScreenInit_KMS(ScreenPtr pScreen, int argc, char **argv)
 	}
 
 	if (info->shadow_fb == TRUE) {
-		if (!shadowSetup(pScreen)) {
+        if (!load_shadowfd(pScrn)){
+            xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
+                       "Shadowfb submodule initialization failed\n");
+            return FALSE;
+
+        }
+        if (!info->shadow_abi.Setup(pScreen)) {
 			xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
 				   "Shadowfb initialization failed\n");
 			return FALSE;

--- a/src/drmmode_display.c
+++ b/src/drmmode_display.c
@@ -374,6 +374,8 @@ create_pixmap_for_fbcon(drmmode_ptr drmmode,
 {
 	ScreenPtr pScreen = pScrn->pScreen;
 	AMDGPUEntPtr pAMDGPUEnt = AMDGPUEntPriv(pScrn);
+    AMDGPUInfoPtr info = AMDGPUPTR(pScrn);
+
 	PixmapPtr pixmap = NULL;
 	drmModeFBPtr fbcon;
 
@@ -394,7 +396,7 @@ create_pixmap_for_fbcon(drmmode_ptr drmmode,
 				    fbcon->pitch, NULL);
 	pixmap->devPrivate.ptr = NULL;
 
-	if (!glamor_egl_create_textured_pixmap(pixmap, fbcon->handle,
+    if (!info->glamor_abi.egl_create_textured_pixmap(pixmap, fbcon->handle,
 					       pixmap->devKind)) {
 		dixDestroyPixmap(pixmap, 0);
 		pixmap = NULL;


### PR DESCRIPTION
draft for now, until figure out  problem:
```
[2026-06-25 14:06:59] (II) modeset(0): Async flip capable
[2026-06-25 14:06:59] (EE) modeset(G0): drmSetMaster failed: Device or resource busy
[2026-06-25 14:06:59] 
Fatal server error:
[2026-06-25 14:06:59] AddScreen/ScreenInit failed for gpu driver 0 -1
```
because on failure - it load modesetting drivers and user have working session.


